### PR TITLE
Support 1.21.92: Clients now include read-only responses again

### DIFF
--- a/src/cosmicpe/awaitform/ResponseProcessor.php
+++ b/src/cosmicpe/awaitform/ResponseProcessor.php
@@ -79,7 +79,6 @@ final class ResponseProcessor{
 		if($this->type === 1){
 			is_array($response) || throw new InvalidArgumentException("Unexpected response: " . gettype($response) . ", expected array");
 			array_is_list($response) || throw new InvalidArgumentException("Unexpected response, expected array to be a list");
-
 			count($response) === count($request["content"]) || throw new InvalidArgumentException("Unexpected response, expected receiving " . (count($request["content"])) .  " values, got " . count($response) . " values");
 			foreach($request["content"] as $index => $request_data){
 				$value = $response[$index];

--- a/src/cosmicpe/awaitform/ResponseProcessor.php
+++ b/src/cosmicpe/awaitform/ResponseProcessor.php
@@ -56,8 +56,7 @@ final class ResponseProcessor{
 	 */
 	private function __construct(
 		readonly private int $type
-	){
-	}
+	){}
 
 	/**
 	 * @param array<string, mixed> $request
@@ -68,33 +67,33 @@ final class ResponseProcessor{
 	 */
 	public function process(array $request, array $tags, mixed $response) : mixed{
 		if($this->type === 0){
-			is_bool($response)||throw new InvalidArgumentException("Unexpected response: {$response}, expected boolean");
+			is_bool($response) || throw new InvalidArgumentException("Unexpected response: {$response}, expected boolean");
 			return $response;
 		}
 		if($this->type === 2){
-			is_int($response)||throw new InvalidArgumentException("Unexpected response: ".gettype($response).", expected integer");
-			isset($request["buttons"][$response])||throw new InvalidArgumentException("Unexpected response: {$response}, index out of range");
+			is_int($response) || throw new InvalidArgumentException("Unexpected response: " . gettype($response) . ", expected integer");
+			isset($request["buttons"][$response]) || throw new InvalidArgumentException("Unexpected response: {$response}, index out of range");
 			assert($response >= 0);
 			return $response;
 		}
 		if($this->type === 1){
-			is_array($response)||throw new InvalidArgumentException("Unexpected response: ".gettype($response).", expected array");
-			array_is_list($response)||throw new InvalidArgumentException("Unexpected response, expected array to be a list");
+			is_array($response) || throw new InvalidArgumentException("Unexpected response: " . gettype($response) . ", expected array");
+			array_is_list($response) || throw new InvalidArgumentException("Unexpected response, expected array to be a list");
 
-			count($response) === count($request["content"])||throw new InvalidArgumentException("Unexpected response, expected receiving ".(count($request["content"]))." values, got ".count($response)." values");
+			count($response) === count($request["content"]) || throw new InvalidArgumentException("Unexpected response, expected receiving " . (count($request["content"])) .  " values, got " . count($response) . " values");
 			foreach($request["content"] as $index => $request_data){
 				$value = $response[$index];
 				switch($request_data["type"]){
 					case "divider":
 					case "header":
 					case "label":
-						$value === null||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]}, expected null");
+						$value === null || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]}, expected null");
 						break;
 					case "dropdown":
-						is_int($value)||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected integer");
-						$value >= 0||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, value is negative");
-						$value < count($request_data["options"])||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, value exceeds range");
-						$response[$index] = match ($tags[$index]["return"]) {
+						is_int($value) || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected integer");
+						$value >= 0 || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, value is negative");
+						$value < count($request_data["options"]) || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, value exceeds range");
+						$response[$index] = match($tags[$index]["return"]){
 							"key" => $value,
 							"value" => $request_data["options"][$value],
 							"mapping" => $tags[$index]["mapping"][$value],
@@ -102,21 +101,21 @@ final class ResponseProcessor{
 						};
 						break;
 					case "input":
-						is_string($value)||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected string");
+						is_string($value) || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected string");
 						break;
 					case "slider":
-						is_int($value)||is_float($value)||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected numeric");
-						$value >= $request_data["min"]||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected value >= {$request_data["min"]}, got {$value}");
-						$value <= $request_data["max"]||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected value <= {$request_data["max"]}, got {$value}");
+						is_int($value) || is_float($value) || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected numeric");
+						$value >= $request_data["min"] || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected value >= {$request_data["min"]}, got {$value}");
+						$value <= $request_data["max"] || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected value <= {$request_data["max"]}, got {$value}");
 						break;
 					case "step_slider":
-						is_int($value)||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected integer");
-						$value >= 0||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, value is negative");
-						$value < count($request_data["steps"])||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, value exceeds range");
+						is_int($value) || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected integer");
+						$value >= 0 || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, value is negative");
+						$value < count($request_data["steps"]) || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, value exceeds range");
 						$response[$index] = $request_data["steps"][$value];
 						break;
 					case "toggle":
-						is_bool($value)||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected boolean");
+						is_bool($value) || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected boolean");
 						break;
 				}
 			}

--- a/src/cosmicpe/awaitform/ResponseProcessor.php
+++ b/src/cosmicpe/awaitform/ResponseProcessor.php
@@ -56,7 +56,8 @@ final class ResponseProcessor{
 	 */
 	private function __construct(
 		readonly private int $type
-	){}
+	){
+	}
 
 	/**
 	 * @param array<string, mixed> $request
@@ -67,43 +68,33 @@ final class ResponseProcessor{
 	 */
 	public function process(array $request, array $tags, mixed $response) : mixed{
 		if($this->type === 0){
-			is_bool($response) || throw new InvalidArgumentException("Unexpected response: {$response}, expected boolean");
+			is_bool($response)||throw new InvalidArgumentException("Unexpected response: {$response}, expected boolean");
 			return $response;
 		}
 		if($this->type === 2){
-			is_int($response) || throw new InvalidArgumentException("Unexpected response: " . gettype($response) . ", expected integer");
-			isset($request["buttons"][$response]) || throw new InvalidArgumentException("Unexpected response: {$response}, index out of range");
+			is_int($response)||throw new InvalidArgumentException("Unexpected response: ".gettype($response).", expected integer");
+			isset($request["buttons"][$response])||throw new InvalidArgumentException("Unexpected response: {$response}, index out of range");
 			assert($response >= 0);
 			return $response;
 		}
 		if($this->type === 1){
-			is_array($response) || throw new InvalidArgumentException("Unexpected response: " . gettype($response) . ", expected array");
-			array_is_list($response) || throw new InvalidArgumentException("Unexpected response, expected array to be a list");
-			$_response = array_fill(0, count($request["content"]), null);
-			$offset = 0;
-			foreach($request["content"] as $index => $request_data){
-				if(isset($tags[$index]["readonly"]) && $tags[$index]["readonly"]){
-					$offset++;
-				}else{
-					array_key_exists($index - $offset, $response) || throw new InvalidArgumentException("Unexpected response, no value supplied for {$request_data["type"]} {$request_data["text"]}");
-					$_response[$index] = $response[$index - $offset];
-				}
-			}
-			count($response) === count($request["content"]) - $offset || throw new InvalidArgumentException("Unexpected response, expected receiving " . (count($request["content"]) - $offset) .  " values, got " . count($response) . " values");
-			$response = $_response;
+			is_array($response)||throw new InvalidArgumentException("Unexpected response: ".gettype($response).", expected array");
+			array_is_list($response)||throw new InvalidArgumentException("Unexpected response, expected array to be a list");
+
+			count($response) === count($request["content"])||throw new InvalidArgumentException("Unexpected response, expected receiving ".(count($request["content"]))." values, got ".count($response)." values");
 			foreach($request["content"] as $index => $request_data){
 				$value = $response[$index];
 				switch($request_data["type"]){
 					case "divider":
 					case "header":
 					case "label":
-						$value === null || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]}, expected null");
+						$value === null||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]}, expected null");
 						break;
 					case "dropdown":
-						is_int($value) || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected integer");
-						$value >= 0 || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, value is negative");
-						$value < count($request_data["options"]) || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, value exceeds range");
-						$response[$index] = match($tags[$index]["return"]){
+						is_int($value)||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected integer");
+						$value >= 0||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, value is negative");
+						$value < count($request_data["options"])||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, value exceeds range");
+						$response[$index] = match ($tags[$index]["return"]) {
 							"key" => $value,
 							"value" => $request_data["options"][$value],
 							"mapping" => $tags[$index]["mapping"][$value],
@@ -111,21 +102,21 @@ final class ResponseProcessor{
 						};
 						break;
 					case "input":
-						is_string($value) || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected string");
+						is_string($value)||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected string");
 						break;
 					case "slider":
-						is_int($value) || is_float($value) || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected numeric");
-						$value >= $request_data["min"] || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected value >= {$request_data["min"]}, got {$value}");
-						$value <= $request_data["max"] || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected value <= {$request_data["max"]}, got {$value}");
+						is_int($value)||is_float($value)||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected numeric");
+						$value >= $request_data["min"]||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected value >= {$request_data["min"]}, got {$value}");
+						$value <= $request_data["max"]||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected value <= {$request_data["max"]}, got {$value}");
 						break;
 					case "step_slider":
-						is_int($value) || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected integer");
-						$value >= 0 || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, value is negative");
-						$value < count($request_data["steps"]) || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, value exceeds range");
+						is_int($value)||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected integer");
+						$value >= 0||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, value is negative");
+						$value < count($request_data["steps"])||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, value exceeds range");
 						$response[$index] = $request_data["steps"][$value];
 						break;
 					case "toggle":
-						is_bool($value) || throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected boolean");
+						is_bool($value)||throw new InvalidArgumentException("Unexpected response for {$request_data["type"]} {$request_data["text"]}, expected boolean");
 						break;
 				}
 			}


### PR DESCRIPTION
## overview
In Minecraft 1.21.90, the client reverted their decision and started sending read-only responses again (see #1). This broke the awaitFrom behavior
This pull request reverts the previous workaround and restores compatibility with the updated protocol behavior

fixed #1 
